### PR TITLE
Don't leak iTunes headers in workflow logs & fix frida

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
       if: ${{ env.NEED_INIT == 1 }}
       run: |
         echo Setup Python Dependencies...
-        pip3 install pywinauto frida Flask
+        pip3 install pywinauto frida==16.4.10 Flask
       working-directory: ${{ github.action_path }}
       shell: cmd
 

--- a/action.yml
+++ b/action.yml
@@ -82,11 +82,7 @@ runs:
       run: |
         sleep 5
         ret=0
-        echo "---------------- Before query headers ----------------"
-        cat /c/get_header.log
         curl --fail-with-body -vv 127.0.0.1:9000 || ret=$?
-        echo "---------------- After query headers ----------------"
-        cat /c/get_header.log
         exit $ret
       working-directory: ${{ github.action_path }}
       shell: bash

--- a/workflow_helper/iTunesDownload/get_header.py
+++ b/workflow_helper/iTunesDownload/get_header.py
@@ -98,7 +98,6 @@ app = Flask(__name__)
 def getHeader():
     hdrUrl = request.args.get('url', "https://p46-buy.itunes.apple.com/WebObjects/MZBuy.woa/wa/buyProduct")
     retHdrs = rpc.get_header(hdrUrl)
-    eprint("Got Headers: %s" % retHdrs)
     kbsync = retHdrs.pop('kbsync')
     guid = retHdrs.pop('X-Guid')
     return jsonify({


### PR DESCRIPTION
iTunes headers gets logged into workflow logs which are public for anyone to see and may contain sensitive authentication session cookies.

[Here's an Example.](https://github.com/Yakov5776/roblox-action-ipadown/actions/runs/9573930687/job/26396281764#step:4:238)

iTunes 头信息会被记录到工作流日志中，而这些日志是公开的，任何人都可以查看，可能包含敏感的认证会话 Cookie
[这是一个例子](https://github.com/Yakov5776/roblox-action-ipadown/actions/runs/9573930687/job/26396281764#step:4:238)